### PR TITLE
Fix broken link on contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We're excited you're considering contributing to our project! Your patches are e
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
 * Make sure you have a [HelloSign account](http://www.hellosign.com)
-* Submit a new [issue ticket](https://github.com/HelloFax/hellosign-java-sdk/issues), assuming one does not already exist.
+* Submit a new [issue ticket](https://github.com/HelloFax/hellosign-dotnet-sdk/issues), assuming one does not already exist.
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * Make sure to include the version you are using which has the issue (and confirm that the issue you are having has not been fixed in a later version)
 * Fork the repository on GitHub


### PR DESCRIPTION
It was pointing to the Java SDK issues rather than the dotnet SDK.
