### PR TITLE
Allowdecline

### DIFF
--- a/HelloSign/HelloSign.cs
+++ b/HelloSign/HelloSign.cs
@@ -574,6 +574,7 @@ namespace HelloSign
             if (signatureRequest.Message != null) request.AddParameter("message", signatureRequest.Message);
             if (signatureRequest.SigningRedirectUrl != null) request.AddParameter("signing_redirect_url", signatureRequest.SigningRedirectUrl);
             if (signatureRequest.TestMode) request.AddParameter("test_mode", "1");
+            if (signatureRequest.AllowDecline) request.AddParameter("allow_decline", "1");
 
             // Add Template IDs
             var i = 0;

--- a/HelloSign/HelloSign.csproj
+++ b/HelloSign/HelloSign.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net35\RestSharp.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net35\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/HelloSign/Models/BaseSignatureRequest.cs
+++ b/HelloSign/Models/BaseSignatureRequest.cs
@@ -25,6 +25,7 @@ namespace HelloSign
         public bool IsForEmbeddedSigning { get; set; }
         public string DetailsUrl { get; set; }
         public string RequesterEmailAddress { get; set; }
+        public bool AllowDecline { get; set; }
         public List<Signature> Signatures { get; set; }
         public List<string> CcEmailAddresses { get; set; }
 
@@ -35,6 +36,7 @@ namespace HelloSign
             Metadata = new Dictionary<String, String>();
             CustomFields = new List<CustomField>();
             CcEmailAddresses = new List<string>();
+            AllowDecline = false;
         }
 
         /// <summary>

--- a/HelloSign/Models/Signature.cs
+++ b/HelloSign/Models/Signature.cs
@@ -18,5 +18,6 @@ namespace HelloSign
         public DateTime LastViewedAt { get; set; }
         public DateTime LastRemindedAt { get; set; }
         public bool HasPin { get; set; }
+        public string DeclineReason { get; set; }
     }
 }

--- a/HelloSign/packages.config
+++ b/HelloSign/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
   <package id="RestSharp" version="105.2.3" targetFramework="net35" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Added AllowDecline to BaseSignatureRequest Class
Set AllowDecline to false in the BaseSignatureRequest constructor
Added allow_decline parameter with a value of 1 in the _PostSignatureRequest method if the AllowDecline is set to true

Tested from my staging server and it works.