### PR TITLE
Add missing fields and a test for custom fields in templates

### DIFF
--- a/HelloSign/Models/CustomField.cs
+++ b/HelloSign/Models/CustomField.cs
@@ -10,5 +10,18 @@ namespace HelloSign
         public string Name { get; set; }
         public string Value { get; set; }
         public string Type { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public bool Required { get; set; }
+        public string ApiId { get; set; }
+        public CustomFieldInfo AvgTextLength { get; set; }
+
+        public class CustomFieldInfo 
+        {
+            public int NumLines { get; set; }
+            public int NumCharsPerLine { get; set; }
+        }
     }
 }

--- a/HelloSignTestApp/Program.cs
+++ b/HelloSignTestApp/Program.cs
@@ -149,6 +149,18 @@ namespace HelloSignTestApp
                 // Download this template's files to disk as a PDF
                 client.DownloadTemplateFiles(firstTemplateId, "template.pdf");
                 Console.WriteLine("Downloaded Template PDF as template.pdf");
+
+                // Get the template itself
+                var template = client.GetTemplate(firstTemplateId);
+                Console.WriteLine("Got Template: " + firstTemplateId);
+
+                // Check the document for custom fields
+                foreach(Document document in template.Documents) {
+                    Console.WriteLine("└ Found Document: " + document.Name);
+                    foreach(CustomField customField in document.CustomFields) {
+                        Console.WriteLine(" └ Found Custom Field: " + customField.Name);
+                    }
+                }
             }
 
             // Send signature request


### PR DESCRIPTION
Added fields from https://github.com/HelloFax/hellosign-dotnet-sdk/pull/45
Created a new test that just gets the template and prints off the custom fields if there are any. This tests the model since the serialization has to work when client.GetTemplate(firstTemplateId); is called.