### PR TITLE
Add Signing Options (set) and Signature Error (get)

### DIFF
--- a/HelloSign/HelloSign.cs
+++ b/HelloSign/HelloSign.cs
@@ -510,6 +510,13 @@ namespace HelloSign
                 request.AddParameter(String.Format("metadata[{0}]", entry.Key), entry.Value); // TODO: Escape characters in key
             }
 
+            // Add Signing Options
+            if (signatureRequest.SigningOptions != null)
+            {
+                // Serialize as JSON string
+                request.AddParameter("signing_options", JsonConvert.SerializeObject(signatureRequest.SigningOptions));
+            }
+
             // Add form fields
             if (signatureRequest.FormFieldsPerDocument != null && signatureRequest.FormFieldsPerDocument.Any())
             {
@@ -614,6 +621,13 @@ namespace HelloSign
             foreach (var entry in signatureRequest.Metadata)
             {
                 request.AddParameter(String.Format("metadata[{0}]", entry.Key), entry.Value); // TODO: Escape characters in key
+            }
+
+            // Add Signing Options
+            if (signatureRequest.SigningOptions != null)
+            {
+                // Serialize as JSON string
+                request.AddParameter("signing_options", JsonConvert.SerializeObject(signatureRequest.SigningOptions));
             }
 
             request.RootElement = "signature_request";
@@ -1193,6 +1207,13 @@ namespace HelloSign
                 request.AddParameter(String.Format("metadata[{0}]", entry.Key), entry.Value); // TODO: Escape characters in key
             }
 
+            // Add Signing Options
+            if (signatureRequest.SigningOptions != null)
+            {
+                // Serialize as JSON string
+                request.AddParameter("signing_options", JsonConvert.SerializeObject(signatureRequest.SigningOptions));
+            }
+
             // TODO: Form fields per doc
 
             request.RootElement = "unclaimed_draft";
@@ -1270,6 +1291,13 @@ namespace HelloSign
             foreach (var entry in signatureRequest.Metadata)
             {
                 request.AddParameter(String.Format("metadata[{0}]", entry.Key), entry.Value); // TODO: Escape characters in key
+            }
+
+            // Add Signing Options
+            if (signatureRequest.SigningOptions != null)
+            {
+                // Serialize as JSON string
+                request.AddParameter("signing_options", JsonConvert.SerializeObject(signatureRequest.SigningOptions));
             }
 
             request.RootElement = "unclaimed_draft";

--- a/HelloSign/HelloSign.csproj
+++ b/HelloSign/HelloSign.csproj
@@ -37,7 +37,6 @@
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net35\RestSharp.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -74,6 +73,7 @@
     <Compile Include="Models\Account.cs" />
     <Compile Include="Models\Oauth.cs" />
     <Compile Include="Models\ApiApp.cs" />
+    <Compile Include="Models\SigningOptions.cs" />
     <Compile Include="HelloSign.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/HelloSign/Models/BaseSignatureRequest.cs
+++ b/HelloSign/Models/BaseSignatureRequest.cs
@@ -29,6 +29,7 @@ namespace HelloSign
         public bool SkipMeNow { get; set; }
         public List<Signature> Signatures { get; set; }
         public List<string> CcEmailAddresses { get; set; }
+        public SigningOptions SigningOptions { get; set; }
 
         public List<Signer> Signers = new List<Signer>();
 

--- a/HelloSign/Models/Signature.cs
+++ b/HelloSign/Models/Signature.cs
@@ -12,6 +12,7 @@ namespace HelloSign
         public string SignatureId { get; set; }
         public string SignerEmailAddress { get; set; }
         public string SignerName { get; set; }
+        public string SignerRole { get; set; }
         public int? Order { get; set; }
         public string StatusCode { get; set; }
         public DateTime SignedAt { get; set; }
@@ -20,5 +21,7 @@ namespace HelloSign
         public bool HasPin { get; set; }
         public string DeclineReason { get; set; }
         public string Error { get; set; }
+        public string ReassignedBy { get; set; }
+        public string ReassignmentReason { get; set; }
     }
 }

--- a/HelloSign/Models/Signature.cs
+++ b/HelloSign/Models/Signature.cs
@@ -19,5 +19,6 @@ namespace HelloSign
         public DateTime LastRemindedAt { get; set; }
         public bool HasPin { get; set; }
         public string DeclineReason { get; set; }
+        public string Error { get; set; }
     }
 }

--- a/HelloSign/Models/SigningOptions.cs
+++ b/HelloSign/Models/SigningOptions.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace HelloSign
+{
+    /// <summary>
+    /// Signing Options for a Signature Request
+    /// </summary>
+    public class SigningOptions
+    {
+        [JsonProperty("draw")]
+        public bool Draw { get; set; } = false;
+        [JsonProperty("type")]
+        public bool Type { get; set; } = false;
+        [JsonProperty("upload")]
+        public bool Upload { get; set; } = false;
+        [JsonProperty("phone")]
+        public bool Phone { get; set; } = false;
+        [JsonProperty("default")]
+        public string Default { get; set; } = "draw";
+    }
+}

--- a/HelloSign/Properties/AssemblyInfo.cs
+++ b/HelloSign/Properties/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 // NOTE: This gets reported in the user-agent string for HTTP requests made.
-[assembly: AssemblyVersion("0.5.8.0")]
+[assembly: AssemblyVersion("0.5.9.0")]
 // [assembly: AssemblyVersion("0.0.0.0")]
 // [assembly: AssemblyFileVersion("0.0.0.0")]

--- a/HelloSignTestApp/Program.cs
+++ b/HelloSignTestApp/Program.cs
@@ -176,6 +176,12 @@ namespace HelloSignTestApp
             request.Metadata.Add("custom_id", "1234");
             request.Metadata.Add("custom_text", "NDA #9");
             request.AllowDecline = true;
+            request.SigningOptions = new SigningOptions
+            {
+                Draw = true,
+                Type = true,
+                Default = "type"
+            };
             request.TestMode = true;
             var response = client.SendSignatureRequest(request);
             Console.WriteLine("New Signature Request ID: " + response.SignatureRequestId);
@@ -284,7 +290,7 @@ namespace HelloSignTestApp
             var fpRequest = new SignatureRequest();
             fpRequest.AddSigner("jack@example.com", "Jack");
             fpRequest.AddSigner("jill@example.com", "Jill");
-            fpRequest.AddFile("HelloSignTestApp/Resources/Test Document.pdf").WithFields(
+            fpRequest.AddFile(System.AppDomain.CurrentDomain.BaseDirectory + "..\\..\\Resources\\Test Document.pdf").WithFields(
                 new FormField("chk1", FormField.TypeCheckbox,     1, 140, 72*1,  36, 36, true, 0),
                 new FormField("txt1", FormField.TypeText,         1, 140, 72*2, 225, 20, true, 0, FormField.ValidationTypeEmailAddress),
                 new FormField("dat1", FormField.TypeDateSigned,   1, 140, 72*3, 225, 52, true, 0),


### PR DESCRIPTION
- Fixes #58 by adding `error` property to Signature model (a child of Signature Request responses)
- Fixes #61 by adding support for setting `signer_options` when creating signature requests / unclaimed drafts
- Bumps version to 0.5.9