### PR TITLE
Cross-platform build support and TestApp improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,17 +381,24 @@ var team = RemoveMemberFromTeam(null, "EMAIL ADDRESS HERE");
 
 ### Windows
 
-Use Visual Studio (Express).
+Use Visual Studio (Express) 2017 or newer.
 
-### Linux (and OSX?) using Mono
+### Linux (and OSX?) using DotNet SDK + Mono
 
-1. Install Mono
-2. Install NuGet
-3. `mkdir packages`
-4. `cd HelloSign`
-5. `nuget install -o ../packages`
-6. `cd ..`
-7. `xbuild` (or `xbuild /p:Configuration=Release` for a non-Debug build)
+To create Debug builds for both the library (HelloSign.dll) and the test application (HelloSignTestApp.dll), run:
+
+```sh
+dotnet build
+```
+
+Or, to create Release builds:
+
+```sh
+dotnet build -c Release
+```
+
+Note: The .NET Framework build target will not be used when running this on a non-Windows system.
+Only .NET Standard 2.0 artifacts will be created.
 
 ### Packaging for NuGet
 

--- a/src/HelloSign/HelloSign.csproj
+++ b/src/HelloSign/HelloSign.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <RepositoryUrl>https://github.com/hellosign/hellosign-dotnet-sdk.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Description>Client library for using the HelloSign API</Description>

--- a/tests/HelloSignTestApp/HelloSignTestApp.csproj
+++ b/tests/HelloSignTestApp/HelloSignTestApp.csproj
@@ -4,7 +4,8 @@
     <ProjectGuid>{99D13956-F763-4F4F-96B9-35B8C91AA836}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
     <Company>HelloSign</Company>
     <Description>An example program demonstrating the HelloSign .NET SDK</Description>
     <PublishUrl>publish\</PublishUrl>

--- a/tests/HelloSignTestApp/Program.cs
+++ b/tests/HelloSignTestApp/Program.cs
@@ -13,7 +13,7 @@ namespace HelloSignTestApp
         {
             Console.WriteLine("└ Attempting to cancel signature request...");
             System.Threading.Thread.Sleep(3000);
-            var retries = 5;
+            var retries = 15;
             while (retries > 0)
             {
                 try
@@ -50,7 +50,11 @@ namespace HelloSignTestApp
             }
 
             // Get API host
-            string apiHost = "api.staging-hellosign.com";
+            string apiHost = Environment.GetEnvironmentVariable("APIHOST");
+            if (String.IsNullOrEmpty(apiHost))
+            {
+                throw new Exception("You must specify the API host/domain via the APIHOST environment variable (e.g. 'api.hellosign.com').");
+            }
             Console.WriteLine("Using HelloSign API at host: " + apiHost);
 
             // Client setup
@@ -173,7 +177,7 @@ namespace HelloSignTestApp
 
             // Get a download URL for this signature request
             Console.WriteLine("Attempting to get a PDF link...");
-            var retries = 5;
+            var retries = 15;
             while (retries > 0)
             {
                 try
@@ -200,7 +204,7 @@ namespace HelloSignTestApp
 
             // Download signature request
             Console.WriteLine("Attempting to download PDF...");
-            retries = 5;
+            retries = 15;
             while (retries > 0)
             {
                 try

--- a/tests/HelloSignTestApp/README.md
+++ b/tests/HelloSignTestApp/README.md
@@ -6,21 +6,29 @@ The program's source is entirely contained within `Program.cs`, which runs perfo
 
 ## Build
 
-Use Visual Studio (Express), or run 'xbuild' (the binary will be generated at `bin/Debug/HelloSignTestApp.exe`).
+Use Visual Studio (Express), or use `dotnet build` (see the README.md at the root of this repository for instructions).
 
 ## Usage
 
 Usage from the command line is as follows:
 
 ```bash
-bin/Debug/HelloSignTestApp.exe [environment]
+bin/Debug/HelloSignTestApp.exe
+```
+
+Or, for .NET Core (required for non-Windows hosts):
+
+```bash
+dotnet tests/HelloSignTestApp/bin/Debug/netcoreapp2.0/HelloSignTestApp.dll
 ```
 
 The **environment** argument specifies which HelloSign environment to connect to, and can be one of: `prod` `staging` `qa` `dev` (defaults to staging)
 
-You **must** set your account's API key via the `APIKEY` environment variable. You could inline your invokation like so:
+You **must** set the API host/domain via the `APIHOST` environment variable and your account's API key via the `APIKEY` environment variable. You could inline your invokation like so:
 
 ```bash
-APIKEY=abcdef1234567890 bin/Debug/HelloSignTestApp.exe prod
+APIHOST=api.hellosign.com \
+APIKEY=abcdef1234567890 \
+dotnet tests/HelloSignTestApp/bin/Debug/netcoreapp2.0/HelloSignTestApp.dll
 ```
 


### PR DESCRIPTION
- Skip .NET Framework build target on non-Windows systems and update build instructions
- Configure TestApp API hostname via environment, and update usage docs