### PR TITLE
Add bulk_send_job endpoints and data structures

### DIFF
--- a/src/HelloSign/HelloSign.cs
+++ b/src/HelloSign/HelloSign.cs
@@ -1461,7 +1461,7 @@ namespace HelloSign
 
         #endregion
 
-        #region Bulk Send Job Method
+        #region Bulk Send Job Methods
 
         /// <summary>
         /// Get a single Bulk Send Job, including a page of its Signature Requests.

--- a/src/HelloSign/HelloSign.cs
+++ b/src/HelloSign/HelloSign.cs
@@ -1458,7 +1458,72 @@ namespace HelloSign
             request.AddUrlSegment("id", clientId);
             Execute(request);
         }
-        
+
+        #endregion
+
+        #region Bulk Send Job Method
+
+        /// <summary>
+        /// Get a single Bulk Send Job, including a page of its Signature Requests.
+        /// </summary>
+        public BulkSendJob GetBulkSendJob(string bulkSendJobId, int? page = null, int? pageSize = null)
+        {
+            RequireAuthentication();
+
+            var request = new RestRequest("bulk_send_job/{id}");
+            request.AddUrlSegment("id", bulkSendJobId);
+            request.RootElement = "bulk_send_job";
+
+            // Special twist on ExecuteList
+            InjectAdditionalParameters(request);
+            var response = client.Execute(request);
+            HandleErrors(response);
+
+            // Unpack list_info
+            deserializer.RootElement = "list_info";
+            var job = deserializer.Deserialize<BulkSendJob>(response);
+
+            // Unpack list of associated SignatureRequests
+            deserializer.RootElement = "signature_requests";
+            job.Items = deserializer.Deserialize<List<SignatureRequest>>(response);
+
+            // Also unpack the BulkSendJobInfo details
+            deserializer.RootElement = "bulk_send_job";
+            job.JobInfo = deserializer.Deserialize<BulkSendJobInfo>(response);
+
+            return job;
+        }
+
+        /// <inheritdoc />
+        public BulkSendJob GetBulkSendJob(BulkSendJobInfo jobInfo, int? page = null, int? pageSize = null)
+        {
+            return this.GetBulkSendJob(jobInfo.BulkSendJobId);
+        }
+
+        /// <summary>
+        /// Get a list of Bulk Send Jobs.
+        ///
+        /// Note that the items returned are of type BulkSendJobInfo, a
+        /// lightweight structure containing information about the Job.
+        /// If you wish to list Signature Requests for a given job, use
+        /// the GetBulkSendJob method to fetch a single job at a time.
+        /// </summary>
+        public ObjectList<BulkSendJobInfo> ListBulkSendJobs(int? page = null, int? pageSize = null)
+        {
+            RequireAuthentication();
+
+            var request = new RestRequest("bulk_send_job/list");
+            if (page != null)
+            {
+                request.AddParameter("page", page);
+            }
+            if (pageSize != null)
+            {
+                request.AddParameter("page_size", pageSize);
+            }
+            return ExecuteList<BulkSendJobInfo>(request, "bulk_send_jobs");
+        }
+
         #endregion
     }
 }

--- a/src/HelloSign/Models/BulkSendJob.cs
+++ b/src/HelloSign/Models/BulkSendJob.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace HelloSign
+{
+    /// <summary>
+    /// Representation of a HelloSign Bulk Send Job object with a list of its
+    /// Signature Requests present.
+    /// </summary>
+    public class BulkSendJob : ObjectList<SignatureRequest>
+    {
+        /// <summary>
+        /// The page of Signature Requests for this Bulk Send Job that was fetched.
+        /// See NumPages/NumResults/Page/PageSize properties for pagination details.
+        /// </summary>
+        /// <value></value>
+        public new List<SignatureRequest> Items { get; set; }
+
+        /// <summary>
+        /// Information about this Bulk Send Job
+        /// </summary>
+        /// <value></value>
+        public BulkSendJobInfo JobInfo { get; set; }
+    }
+}

--- a/src/HelloSign/Models/BulkSendJobInfo.cs
+++ b/src/HelloSign/Models/BulkSendJobInfo.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace HelloSign
+{
+    /// <summary>
+    /// Information about a HelloSign Bulk Send Job object.
+    /// </summary>
+    public class BulkSendJobInfo
+    {
+        public string BulkSendJobId { get; set; }
+
+        /// <summary>
+        /// The total amount of SignatureRequests queued via this job.
+        /// </summary>
+        public int Total { get; set; }
+
+        /// <summary>
+        /// True if you are the owner of this BulkSendJob.
+        /// </summary>
+        public bool IsCreator { get; set; }
+
+        /// <summary>
+        /// Time that the BulkSendJob was created.
+        /// </summary>
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/tests/HelloSignTestApp/Program.cs
+++ b/tests/HelloSignTestApp/Program.cs
@@ -145,6 +145,30 @@ namespace HelloSignTestApp
                 }
             }
 
+            // List Bulk Send Jobs
+            var bulkSendJobInfos = client.ListBulkSendJobs();
+            Console.WriteLine("Found this many bulk send jobs: " + bulkSendJobInfos.NumResults);
+            foreach (BulkSendJobInfo job in bulkSendJobInfos)
+            {
+                string creator = job.IsCreator ? "by me" : "by another user";
+                Console.WriteLine($"└ BulkSendJob: {job.BulkSendJobId} (Total: {job.Total}) Created {creator} on {job.CreatedAt}");
+            }
+
+            // Get a single Bulk Send Job
+            if (bulkSendJobInfos.NumResults > 0)
+            {
+                BulkSendJob job = client.GetBulkSendJob(bulkSendJobInfos.Items[0]);
+                BulkSendJobInfo jobInfo = job.JobInfo;
+                string creator = jobInfo.IsCreator ? "by me" : "by another user";
+                Console.WriteLine($"BulkSendJob: {jobInfo.BulkSendJobId} (Total: {jobInfo.Total}) Created {creator} on {jobInfo.CreatedAt}");
+
+                // List its Signature Requests
+                foreach (var result in job.Items)
+                {
+                    Console.WriteLine("└ Signature request: " + result.SignatureRequestId);
+                }
+            }
+
             // Send signature request
             var request = new SignatureRequest();
             request.Title = "NDA with Acme Co.";


### PR DESCRIPTION
- Adds support for `GET bulk_send_job/:id` (`client.GetBulkSendJob(...)`)
- Adds support for `GET bulk_send_job/list` (`client.ListBulkSendJobs(...)`)
- Adds "test cases" to the test application demonstrating these

Because the `bulk_send_job/:id` API response works a bit differently than most of the other models (it is a hybrid between a record and a "list", as it also fetches a list of signature requests for the job), two new model classes were introduced:

- `BulkSendJobInfo`, which contains the metadata _about_ the job (its ID, when it was created, etc.)
- `BulkSendJob`, which contains a `BulkSendJobInfo` as well as a list of Signature Requests and the standard `ObjectList` properties for pagination (page number, page size, etc.)