### PR TITLE
Support OAuth 2.0 access token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ using HelloSign;
 Create a client object:
 
 ```C#
-var client = new Client("ACCOUNT API KEY HERE"); // Preferred
-// Or...
-var client = new Client("EMAIL ADDRESS HERE", "PASSWORD HERE"); // Not preferred
+// Using your account's API Key
+var client = new Client("ACCOUNT API KEY HERE");
+
+// Or, using an OAuth 2.0 Access Token:
+var client = new Client();
+client.UseOAuth2Authentication("OAUTH ACCESS TOKEN HERE");
 ```
 
 ### Error Handling

--- a/src/HelloSign/HelloSign.cs
+++ b/src/HelloSign/HelloSign.cs
@@ -68,7 +68,9 @@ namespace HelloSign
 
         /// <summary>
         /// Default constructor with no authentication.
-        /// Limited to unauthenticated calls only.
+        ///
+        /// Limited to unauthenticated calls only unless <see cref="UseApiKeyAuthentication"/>
+        /// or <see cref="UseOAuth2Authentication"/> is subsequently called.
         /// </summary>
         public Client()
         {
@@ -91,8 +93,29 @@ namespace HelloSign
         /// <param name="apiKey">Your HelloSign account API key.</param>
         public Client(string apiKey) : this()
         {
+            this.UseApiKeyAuthentication(apiKey);
+        }
+
+        /// <summary>
+        /// Use an API Key to authenticate future requests.
+        /// See: https://app.hellosign.com/api/documentation#Authentication
+        /// </summary>
+        /// <param name="apiKey">Your HelloSign account API key.</param>
+        public void UseApiKeyAuthentication(string apiKey)
+        {
             this.apiKey = apiKey;
             client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(apiKey, "");
+        }
+
+        /// <summary>
+        /// Use an OAuth 2.0 Access Token to authenticate future requests.
+        /// See: https://app.hellosign.com/api/oauthWalkthrough
+        /// </summary>
+        /// <see href="https://app.hellosign.com/api/oauthWalkthrough"></see>
+        /// <param name="accessToken"></param>
+        public void UseOAuth2Authentication(string accessToken)
+        {
+            client.Authenticator = new RestSharp.Authenticators.OAuth2AuthorizationRequestHeaderAuthenticator(accessToken, "Bearer");
         }
 
         private void HandleErrors(IRestResponse response)


### PR DESCRIPTION
Adds the ability to authenticate client requests using on an account's behalf using an access token:

```c#
var client = new Client();
client.UseOAuth2Authentication("OAUTH ACCESS TOKEN HERE");
// ...
```

- Fixes #41 
- Fixes #79 