### PR TITLE
Add SMS verification parameter

### DIFF
--- a/src/HelloSign/HelloSign.cs
+++ b/src/HelloSign/HelloSign.cs
@@ -1247,7 +1247,6 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
-                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
                 i++;
             }
 
@@ -1350,7 +1349,6 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
-                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
             }
 
             // Add CCs

--- a/src/HelloSign/HelloSign.cs
+++ b/src/HelloSign/HelloSign.cs
@@ -513,6 +513,7 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
+                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
                 i++;
             }
 
@@ -643,6 +644,7 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
+                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
             }
 
             // Add CCs
@@ -1245,6 +1247,7 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
+                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
                 i++;
             }
 
@@ -1347,6 +1350,7 @@ namespace HelloSign
                 request.AddParameter(prefix + "[name]", signer.Name);
                 if (signer.Order != null) request.AddParameter(prefix + "[order]", signer.Order);
                 if (signer.Pin != null) request.AddParameter(prefix + "[pin]", signer.Pin);
+                if (signer.SmsPhoneNumber != null) request.AddParameter(prefix + "[sms_phone_number]", signer.SmsPhoneNumber);
             }
 
             // Add CCs

--- a/src/HelloSign/Models/BaseSignatureRequest.cs
+++ b/src/HelloSign/Models/BaseSignatureRequest.cs
@@ -53,7 +53,7 @@ namespace HelloSign
         /// <param name="smsPhoneNumber"></param>
         public void AddSigner(string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null)
         {
-            Signers.Add(new Signer(emailAddress, name, order, pin, smsPhoneNumber));
+            Signers.Add(new Signer(emailAddress, name, order, pin, null, smsPhoneNumber));
         }
 
         /// <summary>

--- a/src/HelloSign/Models/BaseSignatureRequest.cs
+++ b/src/HelloSign/Models/BaseSignatureRequest.cs
@@ -50,9 +50,10 @@ namespace HelloSign
         /// <param name="name"></param>
         /// <param name="order"></param>
         /// <param name="pin"></param>
-        public void AddSigner(string emailAddress, string name, int? order = null, string pin = null)
+        /// <param name="smsPhoneNumber"></param>
+        public void AddSigner(string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null)
         {
-            Signers.Add(new Signer(emailAddress, name, order, pin));
+            Signers.Add(new Signer(emailAddress, name, order, pin, smsPhoneNumber));
         }
 
         /// <summary>

--- a/src/HelloSign/Models/Signer.cs
+++ b/src/HelloSign/Models/Signer.cs
@@ -19,9 +19,9 @@ namespace HelloSign
         /// <param name="Name"></param>
         /// <param name="Order">Optional order of signing, starting from 1. If any Signer has Order set, then all must.</param>
         /// <param name="Pin">Optional 4- to 12-digit passphrase the signer must use to access the document.</param>
-        /// <param name="SmsPhoneNumber">Optional Phone number for SMS verification</param>
         /// <param name="role">Optional Role name (if this is for a Template)</param>
-        public Signer(string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null, string role = null)
+        /// <param name="SmsPhoneNumber">Optional Phone number for SMS verification</param>
+        public Signer(string emailAddress, string name, int? order = null, string pin = null, string role = null, string smsPhoneNumber = null)
         {
             EmailAddress = emailAddress;
             Name = name;

--- a/src/HelloSign/Models/Signer.cs
+++ b/src/HelloSign/Models/Signer.cs
@@ -10,6 +10,7 @@ namespace HelloSign
         public string EmailAddress { get; set; }
         public string Pin { get; set; }
         public string Role { get; set; }
+        public string SmsPhoneNumber { get; set; }
 
         /// <summary>
         /// Create a new Signer object quickly.
@@ -18,14 +19,16 @@ namespace HelloSign
         /// <param name="Name"></param>
         /// <param name="Order">Optional order of signing, starting from 1. If any Signer has Order set, then all must.</param>
         /// <param name="Pin">Optional 4- to 12-digit passphrase the signer must use to access the document.</param>
-        /// <param name="role">Role name (if this is for a Template)</param>
-        public Signer(string emailAddress, string name, int? order = null, string pin = null, string role = null)
+        /// <param name="SmsPhoneNumber">Optional Phone number for SMS verification</param>
+        /// <param name="role">Optional Role name (if this is for a Template)</param>
+        public Signer(string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null, string role = null)
         {
             EmailAddress = emailAddress;
             Name = name;
             Order = order;
             Pin = pin;
             Role = role;
+            SmsPhoneNumber = smsPhoneNumber;
         }
     }
 }

--- a/src/HelloSign/Models/TemplateSignatureRequest.cs
+++ b/src/HelloSign/Models/TemplateSignatureRequest.cs
@@ -40,7 +40,7 @@ namespace HelloSign
         /// <param name="pin"></param>
         public void AddSigner(string role, string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null)
         {
-            Signers.Add(new Signer(emailAddress, name, order, pin, smsPhoneNumber, role));
+            Signers.Add(new Signer(emailAddress, name, order, pin, role, smsPhoneNumber));
         }
 
         /// <summary>

--- a/src/HelloSign/Models/TemplateSignatureRequest.cs
+++ b/src/HelloSign/Models/TemplateSignatureRequest.cs
@@ -38,9 +38,9 @@ namespace HelloSign
         /// <param name="name"></param>
         /// <param name="order"></param>
         /// <param name="pin"></param>
-        public void AddSigner(string role, string emailAddress, string name, int? order = null, string pin = null)
+        public void AddSigner(string role, string emailAddress, string name, int? order = null, string pin = null, string smsPhoneNumber = null)
         {
-            Signers.Add(new Signer(emailAddress, name, order, pin, role));
+            Signers.Add(new Signer(emailAddress, name, order, pin, smsPhoneNumber, role));
         }
 
         /// <summary>


### PR DESCRIPTION
- Adds SMS verification parameter `sms_phone_number` in `Signer` model
- Parameter is supported in the following API endpoints:
```
signature_request/send
signature_request/send_with_template
signature_request/create_embedded
signature_request/create_embedded_with_template
```