### PR TITLE
Fix issue - do not encode form parameter if its type is string or int

### DIFF
--- a/src/Org.HelloSign/Client/ClientUtils.cs
+++ b/src/Org.HelloSign/Client/ClientUtils.cs
@@ -276,6 +276,16 @@ namespace Org.HelloSign.Client
                     continue;
                 }
 
+                if (item.Value is string or int)
+                {
+                    requestOptions.FormParameters.Add(
+                        item.Name,
+                        item.Value.ToString()
+                    );
+                    
+                    continue;
+                }
+
                 if (item.Value is List<Stream> streams)
                 {
                     for (var i = 0; i < streams.Count; i++)

--- a/templates/ClientUtils.mustache
+++ b/templates/ClientUtils.mustache
@@ -285,6 +285,16 @@ namespace {{packageName}}.Client
                     continue;
                 }
 
+                if (item.Value is string or int)
+                {
+                    requestOptions.FormParameters.Add(
+                        item.Name,
+                        item.Value.ToString()
+                    );
+
+                    continue; 
+                }
+
                 if (item.Value is List<Stream> streams)
                 {
                     for (var i = 0; i < streams.Count; i++)


### PR DESCRIPTION
Fix issue -  C# SDK incorrectly double encoding the string parameters when form parameter is in used (i.e. file is attached)

Before:
![Screen Shot 2022-08-10 at 5 38 11 PM](https://user-images.githubusercontent.com/1972467/184260934-4b38adce-6374-4bd3-a4d8-5780add41654.png)

After:
<img width="721" alt="Screen Shot 2022-08-11 at 4 54 02 PM" src="https://user-images.githubusercontent.com/1972467/184261201-24178d9b-203e-404c-930b-e59ff885ed10.png">

